### PR TITLE
add --update flag to bump flake inputs before rebuild

### DIFF
--- a/src/home.rs
+++ b/src/home.rs
@@ -52,7 +52,8 @@ impl HomeRebuildArgs {
 
         let flakeref = format!(
             "{}#homeConfigurations.{}.config.home.activationPackage",
-            &self.common.flakeref.deref(), hm_config_name
+            &self.common.flakeref.deref(),
+            hm_config_name
         );
 
         commands::BuildCommandBuilder::default()
@@ -81,8 +82,16 @@ impl HomeRebuildArgs {
             let confirmation = dialoguer::Confirm::new().default(false).interact()?;
 
             if !confirmation {
-                return Ok(())
+                return Ok(());
             }
+        }
+
+        if self.common.update {
+            commands::CommandBuilder::default()
+                .args(&["nix", "flake", "update"])
+                .message("Updating flake")
+                .build()?
+                .exec()?;
         }
 
         commands::CommandBuilder::default()

--- a/src/home.rs
+++ b/src/home.rs
@@ -56,6 +56,14 @@ impl HomeRebuildArgs {
             hm_config_name
         );
 
+        if self.common.update {
+            commands::CommandBuilder::default()
+                .args(&["nix", "flake", "update", &self.common.flakeref])
+                .message("Updating flake")
+                .build()?
+                .exec()?;
+        }
+
         commands::BuildCommandBuilder::default()
             .flakeref(&flakeref)
             .extra_args(&["--out-link", out_link_str])
@@ -84,14 +92,6 @@ impl HomeRebuildArgs {
             if !confirmation {
                 return Ok(());
             }
-        }
-
-        if self.common.update {
-            commands::CommandBuilder::default()
-                .args(&["nix", "flake", "update"])
-                .message("Updating flake")
-                .build()?
-                .exec()?;
         }
 
         commands::CommandBuilder::default()

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -123,6 +123,10 @@ pub struct CommonRebuildArgs {
     #[arg(env = "FLAKE", value_hint = clap::ValueHint::DirPath)]
     pub flakeref: FlakeRef,
 
+    /// Update flake inputs before building specified configuration
+    #[arg(long, short = 'u')]
+    pub update: bool,
+
     /// Use nix-output-monitor for the build process
     #[arg(
         long,

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -49,6 +49,14 @@ impl OsRebuildArgs {
             hostname
         );
 
+        if self.common.update {
+            commands::CommandBuilder::default()
+                .args(&["nix", "flake", "update", &self.common.flakeref])
+                .message("Updating flake")
+                .build()?
+                .exec()?;
+        }
+
         commands::BuildCommandBuilder::default()
             .flakeref(flake_output)
             .message("Building NixOS configuration")
@@ -94,14 +102,6 @@ impl OsRebuildArgs {
             if !confirmation {
                 return Ok(());
             }
-        }
-
-        if self.common.update {
-            commands::CommandBuilder::default()
-                .args(&["nix", "flake", "update"])
-                .message("Updating flake")
-                .build()?
-                .exec()?;
         }
 
         commands::CommandBuilder::default()

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -96,6 +96,14 @@ impl OsRebuildArgs {
             }
         }
 
+        if self.common.update {
+            commands::CommandBuilder::default()
+                .args(&["nix", "flake", "update"])
+                .message("Updating flake")
+                .build()?
+                .exec()?;
+        }
+
         commands::CommandBuilder::default()
             .args(&[
                 "sudo",


### PR DESCRIPTION
Adds `--update` so the flake inputs are bumped before the rebuild. The current implementation puts the update command *after* the --dry check, so the user will see the diff before they update the system. 