### PR TITLE
Fix evaluation errors in nixos module

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -1,6 +1,7 @@
 self: {
   config,
   lib,
+  pkgs,
   ...
 }: {
   options.nh = with lib; {
@@ -12,7 +13,7 @@ self: {
 
     package = mkOption {
       type = types.package;
-      default = self.packages.${config.nixpkgs.system}.default;
+      default = self.packages.${pkgs.stdenv.hostPlatform}.default;
       description = "Which NH package to use";
     };
 


### PR DESCRIPTION
When using the nixos module in a system that defines `system` via `nixpkgs.hostPlatform`, evaluation fails with the following error:

```
       error: Neither nixpkgs.system nor any other option in nixpkgs.* is meant
       to be read by modules and configurations.
       Use pkgs.stdenv.hostPlatform instead.
```

See a minimal reproduction flake in [this gist](https://gist.github.com/mrene/4cd68bde1af93f959f2587ae0facbe11)

Eval with: 
```
nix eval git+https://gist.github.com/4cd68bde1af93f959f2587ae0facbe11.git#nixosConfigurations.test.config.system.build.toplevel
```