### PR TITLE
fix --update on newer nix versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "nh"
-version = "3.5.5"
+version = "3.5.6"
 dependencies = [
  "ambassador",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nh"
-version = "3.5.5"
+version = "3.5.6"
 edition = "2021"
 license = "EUPL-1.2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/home.rs
+++ b/src/home.rs
@@ -60,7 +60,7 @@ impl HomeRebuildArgs {
 
         if self.common.update {
             commands::CommandBuilder::default()
-                .args(["nix", "flake", "update", &self.common.flakeref])
+                .args(["nix", "flake", "update", "--flake", &self.common.flakeref])
                 .message("Updating flake")
                 .build()?
                 .exec()?;

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -49,7 +49,10 @@ impl OsRebuildArgs {
 
         if self.common.update {
             commands::CommandBuilder::default()
-                .args(["nix", "flake", "update", &self.common.flakeref])
+                // FIXME: if user is running an older version of Nix (i.e pre-`nix flake lock` change)
+                // the below command will fail. maybe check for Nix version and decide on the
+                // command?
+                .args(["nix", "flake", "update", "--flake", &self.common.flakeref])
                 .message("Updating flake")
                 .build()?
                 .exec()?;

--- a/src/search.rs
+++ b/src/search.rs
@@ -118,7 +118,7 @@ impl NHRunnable for SearchArgs {
         debug!(?elapsed);
         trace!(?response);
         println!("Took {}ms", elapsed.as_millis());
-        println!("Most relevant results at end");
+        println!("Most relevant results at the end");
         println!();
 
         let parsed_response: SearchResponse = response


### PR DESCRIPTION
The current iteration of the `--update` flag is missing `--flake` as described by `nix flake update --help`. This MR adds it (big surprise.)

Currently a draft because I'd like to implement a version gate for those below v2.19 instead of failing spectacularly. 