### PR TITLE
fix: "nh os test" do not set nix-profile

### DIFF
--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -126,18 +126,6 @@ impl OsRebuildArgs {
             }
         }
 
-        commands::CommandBuilder::default()
-            .args([
-                "sudo",
-                "nix-env",
-                "--profile",
-                SYSTEM_PROFILE,
-                "--set",
-                out_link_str,
-            ])
-            .build()?
-            .exec()?;
-
         if let Test(_) | Switch(_) = rebuild_type {
             // !! Use the target profile aka spec-namespaced
             let switch_to_configuration =
@@ -152,6 +140,18 @@ impl OsRebuildArgs {
         }
 
         if let Boot(_) | Switch(_) = rebuild_type {
+            commands::CommandBuilder::default()
+                .args([
+                    "sudo",
+                    "nix-env",
+                    "--profile",
+                    SYSTEM_PROFILE,
+                    "--set",
+                    out_link_str,
+                ])
+                .build()?
+                .exec()?;
+
             // !! Use the base profile aka no spec-namespace
             let switch_to_configuration = out_link.join("bin").join("switch-to-configuration");
             let switch_to_configuration = switch_to_configuration.to_str().unwrap();


### PR DESCRIPTION
The new behaviour is consistent with "nixos-rebuild test". The nix-profile is only set on "boot" and "switch".
In the old implementation, builds with "nh os test" were later added to the boot menu on "nh os switch".

Fixes #81.