### PR TITLE
fix: don't clean gcroots if --nogcroots is passed

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -148,7 +148,11 @@ impl NHRunnable for interface::CleanMode {
                             gcroots_tagged.insert(dst, false);
                         }
                         Ok(_) => {
-                            gcroots_tagged.insert(dst, true);
+                            if args.nogcroots {
+                                gcroots_tagged.insert(dst, false);
+                            } else {
+                                gcroots_tagged.insert(dst, true);
+                            }
                         }
                     }
                 } else {


### PR DESCRIPTION
`nh clean <command> --nogcroots` does not ignore any of the gcroots.

I noticed that the [nogcroots](https://github.com/viperML/nh/blob/87ede1ab13beb752b94c23a7b3d03c6b533fa5cb/src/interface.rs#L200) flag is never actually used.

I implemented it such that the gcroots detected by nh are still shown.
![image](https://github.com/viperML/nh/assets/48623763/bc9774ef-bcb3-49ea-859b-5815f4ddbe65)

or would it be better to not detect those if `--nogcroots` is passed?