### PR TITLE
handle permissions issues for `--update` arg

### DIFF
--- a/src/home.rs
+++ b/src/home.rs
@@ -11,7 +11,7 @@ use crate::*;
 use crate::{
     interface::NHRunnable,
     interface::{FlakeRef, HomeArgs, HomeRebuildArgs, HomeSubcommand},
-    util::{compare_semver, get_nix_version},
+    util::{check_perms, compare_semver, get_nix_version},
 };
 
 #[derive(Error, Debug)]
@@ -66,6 +66,8 @@ impl HomeRebuildArgs {
             let nix_version = get_nix_version().unwrap_or_else(|_| {
                 panic!("Failed to get Nix version. Custom Nix fork?");
             });
+
+            check_perms("flake.lock")?;
 
             // Default interface for updating flake inputs
             let mut update_args = vec!["nix", "flake", "update"];

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -8,7 +8,7 @@ use tracing::{debug, info};
 use crate::interface::NHRunnable;
 use crate::interface::OsRebuildType::{self, Boot, Build, Switch, Test};
 use crate::interface::{self, OsRebuildArgs};
-use crate::util::{compare_semver, get_nix_version};
+use crate::util::{check_perms, compare_semver, get_nix_version};
 use crate::*;
 
 const SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
@@ -53,6 +53,8 @@ impl OsRebuildArgs {
             let nix_version = get_nix_version().unwrap_or_else(|_| {
                 panic!("Failed to get Nix version. Custom Nix fork?");
             });
+
+            check_perms("flake.lock")?;
 
             // Default interface for updating flake inputs
             let mut update_args = vec!["nix", "flake", "update"];


### PR DESCRIPTION
Tries to open `flake.lock` with both read and write permissions (which should, in theory, be enough to avoid failures due to flake.lock being owned by root.

If it fails (e.g., due to insufficient permissions or the file not existing), it bails with the error message and a short warning.