### PR TITLE
support standalone home-manager specialisations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,11 @@ or use the `programs.nh.flake` NixOS option.
 ### Specialisations support
 
 nh is capable of detecting which specialisation you are running, so it runs the proper activation script.
-To do so, you need to give nh some information of the spec that is currently running by writing its name to `/etc/specialisation`. The config would look like this:
+To do so, you need to give nh some information of the spec that is currently running.
+
+#### NixOS
+
+System specialisations are read from `/etc/specialisation`. The config would look like this:
 
 ```nix
 {config, pkgs, ...}: {
@@ -66,9 +70,17 @@ To do so, you need to give nh some information of the spec that is currently run
     environment.etc."specialisation".text = "foo";
     # ..rest of config
   };
+}
+```
 
+#### Home-Manager
+
+Home specialisations are read from `~/.local/share/home-manager/specialisation`. The config would look like this:
+
+```nix
+{config, pkgs, ...}: {
   specialisation."bar".configuration = {
-    environment.etc."specialisation".text = "bar";
+    xdg.dataFile."home-manager/specialisation".text = "bar";
     # ..rest of config
   };
 }

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -101,14 +101,6 @@ pub struct OsRebuildArgs {
     #[arg(long, short = 'H', global = true)]
     pub hostname: Option<OsString>,
 
-    /// Name of the specialisation
-    #[arg(long, short)]
-    pub specialisation: Option<String>,
-
-    /// Don't use specialisations
-    #[arg(long, short = 'S')]
-    pub no_specialisation: bool,
-
     /// Extra arguments passed to nix build
     #[arg(last = true)]
     pub extra_args: Vec<String>,
@@ -131,6 +123,14 @@ pub struct CommonRebuildArgs {
     /// Update flake inputs before building specified configuration
     #[arg(long, short = 'u')]
     pub update: bool,
+
+    /// Name of the specialisation
+    #[arg(long, short)]
+    pub specialisation: Option<String>,
+
+    /// Don't use specialisations
+    #[arg(long, short = 'S')]
+    pub no_specialisation: bool,
 
     /// Don't use nix-output-monitor for the build process
     #[arg(long)]

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -87,10 +87,10 @@ impl OsRebuildArgs {
 
         let current_specialisation = std::fs::read_to_string(SPEC_LOCATION).ok();
 
-        let target_specialisation = if self.no_specialisation {
+        let target_specialisation = if self.common.no_specialisation {
             None
         } else {
-            current_specialisation.or_else(|| self.specialisation.to_owned())
+            current_specialisation.or_else(|| self.common.specialisation.to_owned())
         };
 
         debug!("target_specialisation: {target_specialisation:?}");
@@ -104,10 +104,7 @@ impl OsRebuildArgs {
 
         commands::CommandBuilder::default()
             .args(self.common.diff_provider.split_ascii_whitespace())
-            .args([
-                CURRENT_PROFILE,
-                target_profile.to_str().unwrap(),
-            ])
+            .args([CURRENT_PROFILE, target_profile.to_str().unwrap()])
             .message("Comparing changes")
             .build()?
             .exec()?;


### PR DESCRIPTION
Hi thanks for this awesome helper!
I have dark and light theme specialisations in my home-manager config and I would like to pass a specialisation arg to `nh home switch` just like for `nh os switch`. Furthermore I'd like to be able to make `nh home switch` auto-detect and activate the current specialisation in my home-manager config.
I saw in #80 that this is currently not supported. So I tried to implement this myself following along the implementation for the nixos system. This PR is what I came up with. I tested the `~/.local/share/home-manager/specialisation` part with my personal home-manager configuration. However, I can change the path, if a different location is preferred.
I suppose this fixes #80.