### PR TITLE
feat(os & home): add `--result` flag for `build` subcommands

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -132,6 +132,10 @@ pub struct CommonRebuildArgs {
     #[arg(long, short = 'u')]
     pub update: bool,
 
+    /// Create `result` symlink in current directory
+    #[arg(long)]
+    pub result: bool,
+
     /// Don't use nix-output-monitor for the build process
     #[arg(long)]
     pub no_nom: bool,


### PR DESCRIPTION
resolves #133 

I finally had some time to give it a shot :slightly_smiling_face: 
I hope the implementation is ok. First real time writing rust :blush: 

I've successfully verified the behavior for both nixos and home-manager.

Happy to hear you feedback!