### PR TITLE
Specific Env Vars and Edit Command

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -177,12 +177,12 @@ pub fn edit_with(flakeref: FlakeRef, editor: String) -> Result<()> {
         }
     };
 
-    CommandBuilder::default()
-        .args(&vec![editor, flakedir])
-        .message("Editing flake")
-        .build()?
-        .exec()?;
+    Exec::cmd(editor)
+        .args(&vec!["."])
+        .cwd(flakedir)
+        .stderr(Redirection::None)
+        .stdout(Redirection::None)
+        .join()?;
 
     Ok(())
 }
-

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -172,7 +172,7 @@ pub fn edit_with(flakeref: FlakeRef, editor: String) -> Result<()> {
     final_piece = final_piece.split('#').next().unwrap();
     pieces.push(final_piece);
 
-    let flakedir = pieces.join("");
+    let flakedir = pieces.join("/");
 
     Exec::cmd(editor)
         .args(&vec!["."])

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -167,15 +167,12 @@ pub fn edit(flakeref: FlakeRef) -> Result<()> {
 }
 
 pub fn edit_with(flakeref: FlakeRef, editor: String) -> Result<()> {
-    let mut ref_pieces: Vec<&str> = flakeref.split('#').collect();
+    let mut pieces: Vec<&str> = flakeref.split('/').collect();
+    let mut final_piece: &str = pieces.remove(pieces.len() - 1);
+    final_piece = final_piece.split('#').next().unwrap();
+    pieces.push(final_piece);
 
-    let flakedir = match ref_pieces[..] {
-        [x] => x.into(),
-        _ => {
-            ref_pieces.truncate(ref_pieces.len() - 1);
-            ref_pieces.join("#")
-        }
-    };
+    let flakedir = pieces.join("");
 
     Exec::cmd(editor)
         .args(&vec!["."])

--- a/src/home.rs
+++ b/src/home.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn, info, instrument};
 use crate::*;
 use crate::{
     interface::NHRunnable,
-    interface::{FlakeRef, HomeArgs, HomeRebuildArgs, HomeSubcommand},
+    interface::{FlakeRef, HomeArgs, HomeRebuildArgs, HomeSubcommand, HomeEditArgs},
     util::{compare_semver, get_nix_version},
 };
 
@@ -27,8 +27,19 @@ impl NHRunnable for HomeArgs {
             HomeSubcommand::Switch(args) | HomeSubcommand::Build(args) => {
                 args.rebuild(&self.subcommand)
             }
+            HomeSubcommand::Edit(args) => {
+                args.edit()
+            }
             s => bail!("Subcommand {:?} not yet implemented", s),
         }
+    }
+}
+
+impl HomeEditArgs {
+    fn edit(&self) -> Result<()> {
+        let flakeref = self.flakeref.clone().expect("NH_HOME_FLAKE not set");
+
+        commands::edit(flakeref)
     }
 }
 
@@ -154,7 +165,7 @@ impl HomeRebuildArgs {
         drop(out_dir);
 
         Ok(())
-    }
+    }   
 }
 
 fn get_home_output<S: AsRef<str> + std::fmt::Display>(

--- a/src/home.rs
+++ b/src/home.rs
@@ -37,9 +37,7 @@ impl NHRunnable for HomeArgs {
 
 impl HomeEditArgs {
     fn edit(&self) -> Result<()> {
-        let flakeref = self.flakeref.clone().expect("NH_HOME_FLAKE not set");
-
-        commands::edit(flakeref)
+        commands::edit(self.flakeref.clone())
     }
 }
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -5,7 +5,7 @@ use color_eyre::Result;
 use std::{ffi::OsString, ops::Deref, path::PathBuf};
 
 #[derive(Debug, Clone, Default)]
-pub struct FlakeRef(String);
+pub struct FlakeRef(pub String);
 impl From<&str> for FlakeRef {
     fn from(s: &str) -> Self {
         FlakeRef(s.to_string())
@@ -112,6 +112,9 @@ pub struct OsRebuildArgs {
     /// Extra arguments passed to nix build
     #[arg(last = true)]
     pub extra_args: Vec<String>,
+
+    #[arg(env = "NH_OS_FLAKE", value_hint = clap::ValueHint::DirPath)]
+    pub flakeref: Option<FlakeRef>,
 }
 
 #[derive(Debug, Args)]
@@ -123,10 +126,6 @@ pub struct CommonRebuildArgs {
     /// Ask for confirmation
     #[arg(long, short)]
     pub ask: bool,
-
-    /// Flake reference to build
-    #[arg(env = "FLAKE", value_hint = clap::ValueHint::DirPath)]
-    pub flakeref: FlakeRef,
 
     /// Update flake inputs before building specified configuration
     #[arg(long, short = 'u')]
@@ -268,6 +267,9 @@ pub struct HomeRebuildArgs {
     /// Move existing files by backing up with the extension
     #[arg(long, short = 'b')]
     pub backup_extension: Option<String>,
+    
+    #[arg(env = "NH_HOME_FLAKE", value_hint = clap::ValueHint::DirPath)]
+    pub flakeref: Option<FlakeRef>,
 }
 
 #[derive(Debug, Parser)]
@@ -277,3 +279,4 @@ pub struct CompletionArgs {
     #[arg(long, short)]
     pub shell: clap_complete::Shell,
 }
+

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -97,7 +97,7 @@ pub enum OsRebuildType {
 #[derive(Debug, Args)]
 pub struct OsEditArgs {
     #[arg(env = "NH_OS_FLAKE", value_hint = clap::ValueHint::DirPath)]
-    pub flakeref: Option<FlakeRef>,
+    pub flakeref: FlakeRef,
 }
 
 #[derive(Debug, Args)]
@@ -286,7 +286,7 @@ pub struct HomeRebuildArgs {
 #[derive(Debug, Args)]
 pub struct HomeEditArgs {
     #[arg(env = "NH_HOME_FLAKE", value_hint = clap::ValueHint::DirPath)]
-    pub flakeref: Option<FlakeRef>,
+    pub flakeref: FlakeRef,
 }
 
 #[derive(Debug, Parser)]

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -87,9 +87,17 @@ pub enum OsRebuildType {
     Test(OsRebuildArgs),
     /// Build the new configuration
     Build(OsRebuildArgs),
+    /// Open default editor in the flake directory
+    Edit(OsEditArgs),
     /// Show an overview of the system's info
     #[command(hide = true)]
     Info,
+}
+
+#[derive(Debug, Args)]
+pub struct OsEditArgs {
+    #[arg(env = "NH_OS_FLAKE", value_hint = clap::ValueHint::DirPath)]
+    pub flakeref: Option<FlakeRef>,
 }
 
 #[derive(Debug, Args)]
@@ -245,6 +253,9 @@ pub enum HomeSubcommand {
     /// Will check the current $USER and $(hostname) to determine which output to build, unless -c is passed
     Build(HomeRebuildArgs),
 
+    /// Open default editor in flake directory
+    Edit(HomeEditArgs),
+
     /// Show an overview of the installation
     #[command(hide(true))]
     Info,
@@ -268,6 +279,12 @@ pub struct HomeRebuildArgs {
     #[arg(long, short = 'b')]
     pub backup_extension: Option<String>,
     
+    #[arg(env = "NH_HOME_FLAKE", value_hint = clap::ValueHint::DirPath)]
+    pub flakeref: Option<FlakeRef>,
+}
+
+#[derive(Debug, Args)]
+pub struct HomeEditArgs {
     #[arg(env = "NH_HOME_FLAKE", value_hint = clap::ValueHint::DirPath)]
     pub flakeref: Option<FlakeRef>,
 }

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -28,7 +28,7 @@ impl NHRunnable for interface::OsArgs {
 
 impl OsEditArgs {
     fn edit(&self) -> Result<()> {
-        let flakeref = self.flakeref.clone().expect("NH_HOME_FLAKE not set");
+        let flakeref = self.flakeref.clone().expect("NH_OS_FLAKE not set");
         commands::edit(flakeref)
     }
 }

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -28,8 +28,7 @@ impl NHRunnable for interface::OsArgs {
 
 impl OsEditArgs {
     fn edit(&self) -> Result<()> {
-        let flakeref = self.flakeref.clone().expect("NH_OS_FLAKE not set");
-        commands::edit(flakeref)
+        commands::edit(self.flakeref.clone())
     }
 }
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -6,8 +6,8 @@ use color_eyre::Result;
 use tracing::{debug, warn, info};
 
 use crate::interface::NHRunnable;
-use crate::interface::OsRebuildType::{self, Boot, Build, Switch, Test};
-use crate::interface::{self, OsRebuildArgs, FlakeRef};
+use crate::interface::OsRebuildType::{self, Boot, Build, Switch, Test, Edit};
+use crate::interface::{self, OsRebuildArgs, FlakeRef, OsEditArgs};
 use crate::util::{compare_semver, get_nix_version};
 use crate::*;
 
@@ -20,8 +20,16 @@ impl NHRunnable for interface::OsArgs {
     fn run(&self) -> Result<()> {
         match &self.action {
             Switch(args) | Boot(args) | Test(args) | Build(args) => args.rebuild(&self.action),
+            Edit(args) => args.edit(),
             s => bail!("Subcommand {:?} not yet implemented", s),
         }
+    }
+}
+
+impl OsEditArgs {
+    fn edit(&self) -> Result<()> {
+        let flakeref = self.flakeref.clone().expect("NH_HOME_FLAKE not set");
+        commands::edit(flakeref)
     }
 }
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -3,11 +3,11 @@ use std::ops::Deref;
 use color_eyre::eyre::{bail, Context};
 use color_eyre::Result;
 
-use tracing::{debug, info};
+use tracing::{debug, warn, info};
 
 use crate::interface::NHRunnable;
 use crate::interface::OsRebuildType::{self, Boot, Build, Switch, Test};
-use crate::interface::{self, OsRebuildArgs};
+use crate::interface::{self, OsRebuildArgs, FlakeRef};
 use crate::util::{compare_semver, get_nix_version};
 use crate::*;
 
@@ -42,9 +42,14 @@ impl OsRebuildArgs {
         debug!("out_dir: {:?}", out_dir);
         debug!("out_link {:?}", out_link);
 
+        let flakeref = self.flakeref.clone().or_else(|| {
+            warn!("NH_OS_FLAKE not set");
+            std::env::var("FLAKE").ok().map(|s| FlakeRef(s))
+        }).unwrap_or("./".into());
+
         let flake_output = format!(
             "{}#nixosConfigurations.\"{:?}\".config.system.build.toplevel",
-            &self.common.flakeref.deref(),
+            flakeref.deref(),
             hostname
         );
 
@@ -64,7 +69,7 @@ impl OsRebuildArgs {
                 }
             }
 
-            update_args.push(&self.common.flakeref);
+            update_args.push(&flakeref);
 
             debug!("nix_version: {:?}", nix_version);
             debug!("update_args: {:?}", update_args);


### PR DESCRIPTION
# Description

## Specific Env Vars

1) Introduce two new environment variables / arguments: `NH_OS_FLAKE` and `NH_HOME_FLAKE` to set the flake for the NixOS and Home Manager configs respectively.
2) Remove the `FLAKE` argument since it's no longer needed and, as others have pointed out #88, it's not very specific. Note that a fallback is in place to `FLAKE` if `NH_..._FLAKE` is not set so as to make the change a bit more backwards compatible.
3) Fallback to current directory if neither `NH_..._FLAKE` nor `FLAKE` is set.

## Edit Command

Running `nh <os | home> edit` uses the aforementioned env vars to open the default editor (as specified by `EDITOR`) in the flake directory.