### PR TITLE
Return with exit code when --ask is not accepted

### DIFF
--- a/src/clean.rs
+++ b/src/clean.rs
@@ -201,7 +201,7 @@ impl NHRunnable for interface::CleanMode {
         if args.ask {
             info!("Confirm the cleanup plan?");
             if !dialoguer::Confirm::new().default(false).interact()? {
-                return Ok(());
+                bail!("User rejected the cleanup plan");
             }
         }
 

--- a/src/home.rs
+++ b/src/home.rs
@@ -151,7 +151,8 @@ impl HomeRebuildArgs {
             .build()?
             .exec()?;
 
-        // Drop the out dir *only* when we are finished
+        // Make sure out_path is not accidentally dropped
+        // https://docs.rs/tempfile/3.12.0/tempfile/index.html#early-drop-pitfall
         drop(out_path);
 
         Ok(())

--- a/src/home.rs
+++ b/src/home.rs
@@ -136,7 +136,7 @@ impl HomeRebuildArgs {
             let confirmation = dialoguer::Confirm::new().default(false).interact()?;
 
             if !confirmation {
-                return Ok(());
+                bail!("User rejected the new config");
             }
         }
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -134,7 +134,7 @@ impl OsRebuildArgs {
             let confirmation = dialoguer::Confirm::new().default(false).interact()?;
 
             if !confirmation {
-                return Ok(());
+                bail!("User rejected the new config");
             }
         }
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -175,7 +175,8 @@ impl OsRebuildArgs {
                 .exec()?;
         }
 
-        // Drop the out dir *only* when we are finished
+        // Make sure out_path is not accidentally dropped
+        // https://docs.rs/tempfile/3.12.0/tempfile/index.html#early-drop-pitfall
         drop(out_path);
 
         Ok(())


### PR DESCRIPTION
This change exits the program with code 1 when the user rejects changing to the new configuration. The motivation behind this change is to make it easier to wrap this program in scripts.

As i have written in the code, i wanted to propagate the error properly but with color_eyre this doesn't seem to be an option.

I was also a bit confused what `drop(out_dir)` was doing there and couldn't understand the comment, so i changed it to something more clear.