### PR TITLE
nh os repl: init

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -93,7 +93,7 @@ pub struct CommonReplArgs {
 #[clap(verbatim_doc_comment)]
 /// NixOS functionality
 ///
-/// Implements mostly around but not exclusively nixos-rebuild
+/// Implements functionality mostly around but not exclusive to nixos-rebuild
 pub struct OsArgs {
     #[command(subcommand)]
     pub action: OsCommandType,
@@ -113,7 +113,9 @@ pub enum OsCommandType {
     /// Build the new configuration
     Build(OsSubcommandArgs),
 
-    /// Enter a Nix REPL with the target
+    /// Enter a Nix REPL with the target installable
+    ///
+    /// For now, this only supports NixOS configurations via `nh os repl`
     Repl(CommonReplArgs),
 
     /// Show an overview of the system's info

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -84,6 +84,10 @@ pub struct CommonReplArgs {
     #[arg(long, short = 'H', global = true)]
     pub hostname: Option<OsString>,
 
+    /// Name of the flake homeConfigurations attribute, like username@hostname
+    #[arg(long, short, conflicts_with = "flakeref")]
+    pub configuration: Option<String>,
+
     /// Extra arguments passed verbatim to nix repl.
     #[arg(last = true)]
     pub extra_args: Vec<String>,

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -74,33 +74,55 @@ pub enum NHCommand {
     Completions(CompletionArgs),
 }
 
+#[derive(Debug, Args)]
+pub struct CommonReplArgs {
+    /// Flake reference to build
+    #[arg(env = "FLAKE", value_hint = clap::ValueHint::DirPath)]
+    pub flakeref: FlakeRef,
+
+    /// Output to choose from the flakeref. Hostname is used by default
+    #[arg(long, short = 'H', global = true)]
+    pub hostname: Option<OsString>,
+
+    /// Extra arguments passed verbatim to nix repl.
+    #[arg(last = true)]
+    pub extra_args: Vec<String>,
+}
+
 #[derive(Args, Debug)]
 #[clap(verbatim_doc_comment)]
 /// NixOS functionality
 ///
-/// Reimplementations of nixos-rebuild
+/// Implements mostly around but not exclusively nixos-rebuild
 pub struct OsArgs {
     #[command(subcommand)]
-    pub action: OsRebuildType,
+    pub action: OsCommandType,
 }
 
 #[derive(Debug, Subcommand)]
-pub enum OsRebuildType {
+pub enum OsCommandType {
     /// Build and activate the new configuration, and make it the boot default
-    Switch(OsRebuildArgs),
+    Switch(OsSubcommandArgs),
+
     /// Build the new configuration and make it the boot default
-    Boot(OsRebuildArgs),
+    Boot(OsSubcommandArgs),
+
     /// Build and activate the new configuration
-    Test(OsRebuildArgs),
+    Test(OsSubcommandArgs),
+
     /// Build the new configuration
-    Build(OsRebuildArgs),
+    Build(OsSubcommandArgs),
+
+    /// Enter a Nix REPL with the target
+    Repl(CommonReplArgs),
+
     /// Show an overview of the system's info
     #[command(hide = true)]
     Info,
 }
 
 #[derive(Debug, Args)]
-pub struct OsRebuildArgs {
+pub struct OsSubcommandArgs {
     #[command(flatten)]
     pub common: CommonRebuildArgs,
 
@@ -160,7 +182,7 @@ pub struct CommonRebuildArgs {
 
     /// Path to save the result link. Defaults to using a temporary directory.
     #[arg(long, short)]
-    pub out_link: Option<PathBuf>
+    pub out_link: Option<PathBuf>,
 }
 
 #[derive(Args, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod interface;
 mod json;
 mod logging;
 mod nixos;
+mod repl;
 mod search;
 mod util;
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -1,5 +1,5 @@
 use std::ops::Deref;
-use std::{env, vec};
+use std::vec;
 
 use color_eyre::eyre::{bail, Context};
 use color_eyre::Result;
@@ -7,8 +7,8 @@ use color_eyre::Result;
 use tracing::{debug, info, warn};
 
 use crate::interface::NHRunnable;
-use crate::interface::OsRebuildType::{self, Boot, Build, Switch, Test};
-use crate::interface::{self, OsRebuildArgs};
+use crate::interface::OsCommandType::{self, Boot, Build, Repl, Switch, Test};
+use crate::interface::{self, CommonReplArgs, OsSubcommandArgs};
 use crate::util::{compare_semver, get_nix_version};
 use crate::*;
 
@@ -21,13 +21,47 @@ impl NHRunnable for interface::OsArgs {
     fn run(&self) -> Result<()> {
         match &self.action {
             Switch(args) | Boot(args) | Test(args) | Build(args) => args.rebuild(&self.action),
+            Repl(args) => args.repl(),
             s => bail!("Subcommand {:?} not yet implemented", s),
         }
     }
 }
 
-impl OsRebuildArgs {
-    pub fn rebuild(&self, rebuild_type: &OsRebuildType) -> Result<()> {
+impl CommonReplArgs {
+    pub fn repl(&self) -> Result<()> {
+        let mut repl_command = vec!["nix", "repl"];
+
+        let flakeref = format!(
+            "{}#nixosConfigurations.{}",
+            self.flakeref.as_str(),
+            hostname::get()
+                .context("Failed to get hostname")?
+                .to_string_lossy()
+        );
+
+        repl_command.push(&flakeref);
+
+        if !&self.extra_args.is_empty() {
+            for arg in &self.extra_args {
+                repl_command.push(arg);
+            }
+        };
+
+        debug!("repl_command: {:?}", repl_command);
+
+        commands::CommandBuilder::default()
+            .args(repl_command)
+            .message("Entering Nix REPL")
+            .build()?
+            .exec()
+            .unwrap();
+
+        Ok(())
+    }
+}
+
+impl OsSubcommandArgs {
+    pub fn rebuild(&self, rebuild_type: &OsCommandType) -> Result<()> {
         let use_sudo = if self.bypass_root_check {
             warn!("Bypassing root check, now running nix as root");
             false
@@ -125,7 +159,7 @@ impl OsRebuildArgs {
             .build()?
             .exec()?;
 
-        if self.common.dry || matches!(rebuild_type, OsRebuildType::Build(_)) {
+        if self.common.dry || matches!(rebuild_type, OsCommandType::Build(_)) {
             return Ok(());
         }
 

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,0 +1,63 @@
+use std::vec;
+
+use color_eyre::eyre::{bail, Context};
+use color_eyre::Result;
+
+use tracing::debug;
+
+use crate::interface::CommonReplArgs;
+use crate::*;
+
+/// ReplVariant represents the variant of the target REPL. It should be one of
+/// OsRepl or HomeRepl while beig passed to the repl function as an argument.
+///
+/// Only OsRepl (nh os repl) is supported for the time being!
+pub enum ReplVariant {
+    OsRepl,
+    HomeRepl,
+}
+
+impl CommonReplArgs {
+    pub fn repl(&self, repl_variant: ReplVariant) -> Result<()> {
+        let mut repl_command = vec!["nix", "repl"];
+
+        // Push extra arguments to the repl command BEFORE the installable, is passed
+        // to the REPL.
+        if !&self.extra_args.is_empty() {
+            for arg in &self.extra_args {
+                repl_command.push(arg);
+            }
+        };
+
+        // When (or if) HomeRepl is implemented, this can be changed to a more generic value
+        // and made mutable, so that the value is set in the match based on the variant of
+        // the REPL. For the time being, I am setting it here to ensure it lives long enough
+        // to be borrowed later.
+        let flakeref = format!(
+            "{}#nixosConfigurations.{}",
+            self.flakeref.as_str(),
+            hostname::get()
+                .context("Failed to get hostname")?
+                .to_string_lossy()
+        );
+
+        // TODO: Implement match case for HomeRepl.
+        // See nixos.rs for the OsRepl implementation, the interface is now general enough
+        // to be reused without friction.
+        match repl_variant {
+            ReplVariant::OsRepl => repl_command.push(&flakeref),
+            ReplVariant::HomeRepl => bail!("OsRepl is not yet supported."),
+        }
+
+        debug!("flakeref: {:?}", flakeref);
+        debug!("repl_command: {:?}", repl_command);
+
+        commands::CommandBuilder::default()
+            .args(repl_command)
+            .message("Entering Nix REPL")
+            .build()?
+            .exec()
+            .unwrap();
+        Ok(())
+    }
+}

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -29,16 +29,20 @@ impl CommonReplArgs {
             }
         };
 
+        let hostname = match &self.hostname {
+            Some(h) => h.to_owned(),
+            None => hostname::get().context("Failed to get hostname")?,
+        };
+
         // When (or if) HomeRepl is implemented, this can be changed to a more generic value
         // and made mutable, so that the value is set in the match based on the variant of
         // the REPL. For the time being, I am setting it here to ensure it lives long enough
         // to be borrowed later.
+        // P.S. "flakeref" is an incredibly vague name, make sure to change it.
         let flakeref = format!(
             "{}#nixosConfigurations.{}",
             self.flakeref.as_str(),
-            hostname::get()
-                .context("Failed to get hostname")?
-                .to_string_lossy()
+            hostname.to_string_lossy()
         );
 
         // TODO: Implement match case for HomeRepl.


### PR DESCRIPTION
Adds a generic implementation of a `nix repl` wrapper, and a repl subcommand for `nh os` which puts the user into a repl with the active nixosConfiguration. Equivalent of `nix repl .#nixosConfiguration.$HOSTNAME` or entering nix repl and running `:lf nixosConfigurations.<hostname>`.

home repl is not implemented because 1. I conceptually disagree with standalone home-manager and 2. it would depend on functions defined in home.rs, which I would rather not pass around haphazardly - might be implemented properly when there is a more standard library/utility module in nh's codebase.