### PR TITLE
Dev: add darwin build deps

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -18,7 +18,10 @@ mkShell {
     yaml-language-server
   ];
 
-  buildInputs = [ ];
+  buildInputs = lib.optionals stdenv.isDarwin [
+    darwin.apple_sdk.frameworks.SystemConfiguration
+    libiconv
+  ];
 
   env = {
     NH_NOM = "1";


### PR DESCRIPTION
Allows building nh with `cargo build` on darwin. Without this change, you get errors such as
```bash
note: ld: library not found for -liconv
          clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```
when building on darwin with nix devshell.