### PR TITLE
Home: clean up potential trailing newline from nix eval

### DIFF
--- a/src/home.rs
+++ b/src/home.rs
@@ -158,16 +158,18 @@ fn toplevel_for(installable: Installable, push_drv: bool) -> Result<Installable>
                     attribute
                 });
 
-                match res.as_deref() {
-                    Some("true") => {
-                        attribute.push(attr.clone());
-                        if push_drv {
-                            attribute.extend(toplevel);
+                if let Some(res) = res.as_deref() {
+                    match res.trim() {
+                        "true" => {
+                            attribute.push(attr.clone());
+                            if push_drv {
+                                attribute.extend(toplevel);
+                            }
+                            break 'flake;
                         }
-                        break 'flake;
-                    }
-                    _ => {
-                        continue;
+                        _ => {
+                            continue;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When running the latest nh 4 beta, I could not rebuild home manager on darwin due to the output of nix eval outputing a newline, causing nh to think the derivation did not exist.

```bash
DEBUG nh::commands:100: cmd=Exec { nix eval --apply ' x: x ? "caleb@chnorton-mbp" ' '/Users/caleb/projects/nix-config#homeConfigurations' }
DEBUG nh::home:155: res=Some("true\n")
DEBUG nh::commands:100: cmd=Exec { nix eval --apply ' x: x ? "caleb" ' '/Users/caleb/projects/nix-config#homeConfigurations' }
DEBUG nh::home:155: res=Some("false\n")
```

This change addresses that case.

Edit: this issue also happens on an ubuntu machine running nix 2.23.0 (my darwin machine is on nix 2.24.10)