### PR TITLE
fix: do not generated `result`  in pwd without `-o` args

### DIFF
--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -127,7 +127,7 @@ impl DarwinRebuildArgs {
 
         if let Switch = variant {
             Command::new("nix")
-                .args(["build", "--profile", SYSTEM_PROFILE])
+                .args(["build", "--no-link", "--profile", SYSTEM_PROFILE])
                 .arg(out_path.get_path())
                 .elevate(true)
                 .dry(self.common.dry)

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -135,7 +135,7 @@ impl OsRebuildArgs {
         if let Boot | Switch = variant {
             Command::new("nix")
                 .elevate(elevate)
-                .args(["build", "--profile", SYSTEM_PROFILE])
+                .args(["build", "--no-link", "--profile", SYSTEM_PROFILE])
                 .arg(out_path.get_path())
                 .run()?;
 


### PR DESCRIPTION
fix #191

have tested the `-o` function.