### PR TITLE
home.rs: fix bug where the last generation was sometimes not found

### DIFF
--- a/src/home.rs
+++ b/src/home.rs
@@ -64,8 +64,7 @@ impl HomeRebuildArgs {
                 .join(".local/state/nix/profiles/home-manager"),
         ]
         .into_iter()
-        .take_while(|next| next.exists())
-        .next();
+        .find(|next| next.exists());
 
         debug!(?prev_generation);
 


### PR DESCRIPTION
If the first location didn't exist, `take_while` would immediately return.