### PR TITLE
search.rs: include platforms in search results

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -180,6 +180,10 @@ pub struct SearchArgs {
     /// Name of the channel to query (e.g nixos-23.11, nixos-unstable, etc)
     pub channel: String,
 
+    #[arg(long, short = 'P')]
+    /// Show supported platforms for each package
+    pub platforms: bool,
+
     /// Name of the package to search
     pub query: Vec<String>,
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -177,7 +177,7 @@ impl SearchArgs {
                 }
             }
 
-            if !elem.package_platforms.is_empty() {
+            if self.platforms && !elem.package_platforms.is_empty() {
                 println!("  Platforms: {}", elem.package_platforms.join(", "));
             }
 

--- a/src/search.rs
+++ b/src/search.rs
@@ -177,6 +177,10 @@ impl SearchArgs {
                 }
             }
 
+            if !elem.package_platforms.is_empty() {
+                println!("  Platforms: {}", elem.package_platforms.join(", "));
+            }
+
             if let Some(position) = &elem.package_position {
                 let position = position.split(':').next().unwrap();
                 print!("  Defined at: ");


### PR DESCRIPTION
A common use case, for me, is to find what platforms are supported by a package in nixpkgs. This returns those results in the search command. Not sure if you would rather this be gated behind a flag. 

<img width="660" alt="image" src="https://github.com/user-attachments/assets/f7221332-ba1c-4662-8d73-cb89b197421b" />

<img width="1256" alt="image" src="https://github.com/user-attachments/assets/e79d3210-bdb8-4636-b7b6-7cc48f5a2c94" />
