### PR TITLE
darwin: show output on activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
   effect, and both flags are now considered mutually exclusive. If you specify
   the `--update` flag, all flake inputs will be updated. If you specify the
   `--update-input NAME` flag, only the specified flake(s) will be updated.
+- `nh darwin switch` now shows the output from the `darwin-rebuild` activation.
+  This allows you to see more details about the activation from `nix-darwin`, as
+  well as `Home Manager`.
 
 ### Fixed
 

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -157,6 +157,7 @@ impl DarwinRebuildArgs {
                 .message("Activating configuration")
                 .elevate(needs_elevation)
                 .dry(self.common.dry)
+                .show_output(true)
                 .run()?;
         }
 


### PR DESCRIPTION
Show the stdout activation logging so users can actually see whats going on.

Shows `nix-darwin` activation logging and the `home manager` verbose logging, when enabled.

Fixes issue reported https://github.com/nix-community/nh/issues/325#issuecomment-2979569306