### PR TITLE
feat: add --refresh to darwin/home/os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ functionality, under the "Removed" section.
   - It's roughly %4 faster according to testing, but IO is still a limiting
     factor and results may differ.
 - Added more context to some minor debug messages across platform commands.
+- The `--refresh` flag is now treated as a passthrough argument to Nix.
 
 ### Fixed
 

--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -102,13 +102,19 @@ impl DarwinRebuildArgs {
 
         let toplevel = toplevel_for(hostname, processed_installable, "toplevel");
 
-        commands::Build::new(toplevel)
+        let mut build = commands::Build::new(toplevel)
             .extra_arg("--out-link")
             .extra_arg(&out_path)
             .extra_args(&self.extra_args)
             .passthrough(&self.common.passthrough)
             .message("Building Darwin configuration")
-            .nom(!self.common.no_nom)
+            .nom(!self.common.no_nom);
+
+        if self.common.refresh {
+            build = build.extra_arg("--refresh");
+        }
+
+        build
             .run()
             .wrap_err("Failed to build Darwin configuration")?;
 

--- a/src/home.rs
+++ b/src/home.rs
@@ -87,13 +87,19 @@ impl HomeRebuildArgs {
             self.configuration.clone(),
         )?;
 
-        commands::Build::new(toplevel)
+        let mut build = commands::Build::new(toplevel)
             .extra_arg("--out-link")
             .extra_arg(&out_path)
             .extra_args(&self.extra_args)
             .passthrough(&self.common.passthrough)
             .message("Building Home-Manager configuration")
-            .nom(!self.common.no_nom)
+            .nom(!self.common.no_nom);
+
+        if self.common.refresh {
+            build = build.extra_arg("--refresh");
+        }
+
+        build
             .run()
             .wrap_err("Failed to build Home-Manager configuration")?;
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -298,6 +298,10 @@ pub struct CommonRebuildArgs {
     #[arg(long, short, value_enum, default_value_t = DiffType::Auto)]
     pub diff: DiffType,
 
+    /// Refresh flakes to the latest revision
+    #[arg(long)]
+    pub refresh: bool,
+
     #[command(flatten)]
     pub passthrough: NixBuildPassthroughArgs,
 }
@@ -706,10 +710,6 @@ pub struct NixBuildPassthroughArgs {
     #[arg(long)]
     pub accept_flake_config: bool,
 
-    /// Refresh flakes to the latest revision
-    #[arg(long)]
-    pub refresh: bool,
-
     /// Allow impure builds
     #[arg(long)]
     pub impure: bool,
@@ -800,9 +800,6 @@ impl NixBuildPassthroughArgs {
         }
         if self.accept_flake_config {
             args.push("--accept-flake-config".into());
-        }
-        if self.refresh {
-            args.push("--refresh".into());
         }
         if self.impure {
             args.push("--impure".into());

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -164,16 +164,20 @@ impl OsRebuildArgs {
             _ => "Building NixOS configuration",
         };
 
-        commands::Build::new(toplevel)
+        let mut build = commands::Build::new(toplevel)
             .extra_arg("--out-link")
             .extra_arg(&out_path)
             .extra_args(&self.extra_args)
             .passthrough(&self.common.passthrough)
             .builder(self.build_host.clone())
             .message(message)
-            .nom(!self.common.no_nom)
-            .run()
-            .wrap_err("Failed to build configuration")?;
+            .nom(!self.common.no_nom);
+
+        if self.common.refresh {
+            build = build.extra_arg("--refresh");
+        }
+
+        build.run().wrap_err("Failed to build configuration")?;
 
         let current_specialisation = std::fs::read_to_string(SPEC_LOCATION).ok();
 


### PR DESCRIPTION
It's really common when working with remote flakes to always want the
latest upstream ref, and not the local cached one, which is what
`--refresh` is for.

It'd be nice if it was passable directly in `nh` instead of as an extra
arg.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or a please bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/main/CHANGELOG.md

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate docunentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
