### PR TITLE
nixos: add `--install-bootloader` for explicit bootloader installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,22 @@ issue is not necessary, but good to have. Otherwise, general-purpose changes can
 be put in the "Changed" section or, if it's just to remove code or
 functionality, under the "Removed" section.
 -->
+
 ## Unreleased
 
 ### Changed
 
-- `nh os info` now support `--fields` to select which field(s) to display; 
-  also add a per-generation "Closure Size" coloumn.
+- `nh os info` now support `--fields` to select which field(s) to display; also
+  add a per-generation "Closure Size" coloumn.
   ([#375](https://github.com/nix-community/nh/issues/375))
-  
+
+- `nh os switch` and `nh os boot` now support the `--install-bootloader` flag,
+  which will explicitly set `NIXOS_INSTALL_BOOTLOADER` for
+  `switch-to-configuration`. Bootloader behaviour was previously supported by
+  explicitly passing the variable to `nh` commands, which has now been made
+  explicit through the `--install-bootloader` flag.
+  ([#424](https://github.com/nix-community/nh/issues/424))
+
 ## 4.2.0
 
 ### Changed

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -235,6 +235,20 @@ impl Command {
     self
   }
 
+  /// Set an environment variable to a specific value
+  #[must_use]
+  pub fn set_env<K, V>(mut self, key: K, value: V) -> Self
+  where
+    K: AsRef<str>,
+    V: AsRef<str>,
+  {
+    self.env_vars.insert(
+      key.as_ref().to_string(),
+      EnvAction::Set(value.as_ref().to_string()),
+    );
+    self
+  }
+
   /// Configure environment for Nix and NH operations
   #[must_use]
   pub fn with_required_env(mut self) -> Self {

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -214,6 +214,10 @@ pub struct OsRebuildArgs {
   #[arg(long, short = 'S')]
   pub no_specialisation: bool,
 
+  /// Install bootloader for switch and boot commands
+  #[arg(long)]
+  pub install_bootloader: bool,
+
   /// Extra arguments passed to nix build
   #[arg(last = true)]
   pub extra_args: Vec<String>,


### PR DESCRIPTION
NH previously supported passing `NIXOS_INSTALL_BOOTLOADER` variable to the `switch-to-configuration`, which in turn forced an installation of the bootloader. This behaviour was supported, but implcit. As per #424 we now support the `--install-bootloader` flag that makes this behaviour explicit and documented.

Change-Id: I6a6a69643f4b16816728dcaa6a66b675f9fe0ff2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --install-bootloader flag to OS rebuild commands so users can explicitly request bootloader installation during a rebuild; default behavior unchanged unless the flag is set.

* **Documentation**
  * Updated changelog entry describing the new --install-bootloader option.

* **Chores**
  * Minor CLI logging and developer-facing improvements around environment handling and command assembly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->