### PR TITLE
generations: cleanup; hide empty columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ functionality, under the "Removed" section.
 
 ### Changed
 
+- `nh os info` now hides empty columns.
+
 - `nh os info` now support `--fields` to select which field(s) to display; also
   add a per-generation "Closure Size" coloumn.
   ([#375](https://github.com/nix-community/nh/issues/375))

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -96,7 +96,7 @@ pub fn from_dir(generation_dir: &Path) -> Option<u64> {
 }
 
 #[must_use]
-pub fn get_closure_size(generation_dir: &Path) -> std::string::String {
+pub fn get_closure_size(generation_dir: &Path) -> String {
   let store_path = generation_dir
     .read_link()
     .unwrap_or_else(|_| generation_dir.to_path_buf());


### PR DESCRIPTION
Previously, `nh os info` always printed all columns, which is frankly unnecessary if you're missing
things such as specializations.

- Remove empty columns from the print output.
- Furthermore, fix formatting for systems with more than 1000 genererations.

Previous:
<img width="1410" height="353" alt="image" src="https://github.com/user-attachments/assets/c494d81f-5737-4e08-b659-4922fad54515" />

New:
<img width="947" height="351" alt="image" src="https://github.com/user-attachments/assets/2a79999e-b156-4f28-9ce0-271dce29fc51" />




<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [X] I have updated the [changelog] as per my changes
- [X] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [X] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [X] My changes are consistent with the rest of the codebase
- Correctness
  - [X] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [X] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [X] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * nh os info now hides empty columns (e.g., Config Revision, Specialisations) when no data is available.
  * Displays “Unknown” for missing values (e.g., closure size) to improve clarity.
  * Table headers and column widths automatically adjust to visible fields for cleaner output.

* **Documentation**
  * Updated changelog under Unreleased/Changed to note that nh os info hides empty columns.
  * Retains existing note that nh os info supports --fields selection with an additional per-generation “Closure Size” column.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->