### PR TITLE
meta: resolve fixable clippy warning

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -131,8 +131,8 @@ pub enum ElevationStrategy {
 impl ElevationStrategy {
   pub fn resolve(&self) -> Result<PathBuf> {
     match self {
-      ElevationStrategy::Auto => Self::choice(),
-      ElevationStrategy::Prefer(program) => {
+      Self::Auto => Self::choice(),
+      Self::Prefer(program) => {
         which(program).or_else(|_| {
           let auto = Self::choice()?;
           warn!(
@@ -143,7 +143,7 @@ impl ElevationStrategy {
           Ok(auto)
         })
       },
-      ElevationStrategy::Force(program) => Ok(program.into()),
+      Self::Force(program) => Ok(program.into()),
     }
   }
 
@@ -224,14 +224,14 @@ impl Command {
 
   /// Set whether to perform a dry run.
   #[must_use]
-  pub fn dry(mut self, dry: bool) -> Self {
+  pub const fn dry(mut self, dry: bool) -> Self {
     self.dry = dry;
     self
   }
 
   /// Set whether to show command output.
   #[must_use]
-  pub fn show_output(mut self, show_output: bool) -> Self {
+  pub const fn show_output(mut self, show_output: bool) -> Self {
     self.show_output = show_output;
     self
   }

--- a/src/generations.rs
+++ b/src/generations.rs
@@ -70,7 +70,7 @@ struct ColumnWidths {
 }
 
 impl Field {
-  fn column_info(&self, width: ColumnWidths) -> (&'static str, usize) {
+  const fn column_info(&self, width: ColumnWidths) -> (&'static str, usize) {
     match self {
       Self::Id => ("Generation No", width.id),
       Self::Date => ("Build Date", width.date),
@@ -173,6 +173,7 @@ pub fn get_closure_size(generation_dir: &Path) -> String {
   )
 }
 
+#[must_use]
 pub fn describe(generation_dir: &Path) -> Option<GenerationInfo> {
   let generation_number = from_dir(generation_dir)?;
   let closure_size = get_closure_size(generation_dir);

--- a/src/home.rs
+++ b/src/home.rs
@@ -135,7 +135,7 @@ impl HomeRebuildArgs {
     let target_profile: PathBuf = if let Some(spec) = &target_specialisation {
       out_path.join("specialisation").join(spec)
     } else {
-      out_path.clone()
+      out_path
     };
 
     // just do nothing for None case (fresh installs)
@@ -316,9 +316,7 @@ where
           };
           tried.push(current_try_attr.clone());
 
-          if let Some("true") =
-            check_res.map(|s| s.trim().to_owned()).as_deref()
-          {
+          if check_res.map(|s| s.trim().to_owned()).as_deref() == Some("true") {
             debug!("Using automatically detected configuration: {}", attr_name);
             attribute.push(attr_name);
             if push_drv {

--- a/src/installable.rs
+++ b/src/installable.rs
@@ -57,7 +57,7 @@ impl FromArgMatches for Installable {
 
     if let Some(e) = expr {
       return Ok(Self::Expression {
-        expression: e.to_string(),
+        expression: e.clone(),
         attribute:  parse_attribute(installable.cloned().unwrap_or_default()),
       });
     }
@@ -286,7 +286,7 @@ impl Installable {
         attribute,
       } => {
         res.push(String::from("--expr"));
-        res.push(expression.to_string());
+        res.push(expression.clone());
         res.push(join_attribute(attribute));
       },
       Self::Store { path } => {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -31,15 +31,15 @@ where
 
     match *level {
       Level::ERROR => {
-        write!(writer, "{} ", Paint::new("ERROR").fg(Color::Red))?
+        write!(writer, "{} ", Paint::new("ERROR").fg(Color::Red))?;
       },
       Level::WARN => write!(writer, "{} ", Paint::new("!").fg(Color::Yellow))?,
       Level::INFO => write!(writer, "{} ", Paint::new(">").fg(Color::Green))?,
       Level::DEBUG => {
-        write!(writer, "{} ", Paint::new("DEBUG").fg(Color::Blue))?
+        write!(writer, "{} ", Paint::new("DEBUG").fg(Color::Blue))?;
       },
       Level::TRACE => {
-        write!(writer, "{} ", Paint::new("TRACE").fg(Color::Cyan))?
+        write!(writer, "{} ", Paint::new("TRACE").fg(Color::Cyan))?;
       },
     }
 

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -329,10 +329,8 @@ impl OsRebuildArgs {
     target_hostname: &str,
     final_attr: Option<&String>,
   ) -> Result<Installable> {
-    let installable = (get_nh_os_flake_env()?).map_or_else(
-      || self.common.installable.clone(),
-      |flake_installable| flake_installable,
-    );
+    let installable = (get_nh_os_flake_env()?)
+      .unwrap_or_else(|| self.common.installable.clone());
 
     Ok(toplevel_for(
       target_hostname,

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,7 +14,7 @@ use tracing::{debug, info};
 
 use crate::commands::{Command, ElevationStrategy};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NixVariant {
   Nix,
   Lix,


### PR DESCRIPTION
Exactly what it says, I ran `cargo clippy --fix`, briefly checked the generated code to make sure it looked reasonable, and that's what I'm committing. This reduces the number of clippy warnings I see by about 10.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Builder methods made eligible for compile-time use to enable minor optimizations.
  * Streamlined error handling in logging paths.
  * Ownership/cloning reduced in a few places to avoid unnecessary copies.

* **Chores**
  * Enhanced type-safety by extending derived equality for an enum.
  * A public utility now signals its return should be used to avoid accidental ignores.
  * Minor control-flow tweaks for automatic configuration detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->