### PR TITLE
util: drop `hostname` crate; use `nix` crate for hostname features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -214,7 +214,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -874,17 +874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
-name = "hostname"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
-dependencies = [
- "cfg-if",
- "libc",
- "windows-link 0.1.3",
-]
-
-[[package]]
 name = "hotpath"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,7 +1417,6 @@ dependencies = [
  "color-eyre",
  "dix",
  "elasticsearch-dsl",
- "hostname",
  "hotpath",
  "humantime",
  "inquire",
@@ -3008,7 +2996,7 @@ checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.0",
+ "windows-link",
  "windows-result",
  "windows-strings",
 ]
@@ -3037,12 +3025,6 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
@@ -3053,7 +3035,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -3062,7 +3044,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -3098,7 +3080,7 @@ version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -3123,7 +3105,7 @@ version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,10 @@ clap-verbosity-flag = { default-features = false, features = [ "tracing" ], vers
 color-eyre = { default-features = false, features = [ "track-caller" ], version = "0.6.5" }
 dix = "1.3.0"
 elasticsearch-dsl = "0.4.24"
-hostname = "0.4.1"
 hotpath = { optional = true, version = "0.7.5" }
 humantime = "2.3.0"
 inquire = { default-features = false, features = [ "crossterm" ], version = "0.9.1" }
-nix = { default-features = false, features = [ "fs", "user" ], version = "0.30.1" }
+nix = { default-features = false, features = [ "fs", "user", "hostname" ], version = "0.30.1" }
 regex = "1.12.2"
 reqwest = { default-features = false, features = [
   "rustls-tls-native-roots",

--- a/src/util.rs
+++ b/src/util.rs
@@ -241,15 +241,11 @@ pub fn get_hostname(supplied_hostname: Option<String>) -> Result<String> {
   #[cfg(not(target_os = "macos"))]
   {
     use color_eyre::eyre::Context;
-    Ok(
-      hostname::get()
-        .context("Failed to get hostname, and no hostname supplied")?
-        .to_str()
-        .map_or_else(
-          || String::from("unknown-hostname"),
-          std::string::ToString::to_string,
-        ),
-    )
+
+    nix::unistd::gethostname()
+      .context("Failed to get hostname, and no hostname supplied")?
+      .into_string()
+      .map_err(|_| eyre::eyre!("Hostname contains invalid UTF-8"))
   }
   #[cfg(target_os = "macos")]
   {


### PR DESCRIPTION
I'm on a sidequest to distract myself from #428. That PR is also probably finished but I don't want to test it :(

Updates how the hostname is retrieved on non-macOS platforms and drops the `hostname` crate since `nix` can already do it. Also slightly improves error handling for invalid UTF-8 hostnames. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * `nix` dependency now includes hostname support (adds hostname feature); standalone `hostname` dependency removed.

* **Improvements**
  * Hostname detection on non-macOS systems improved with stricter UTF-8 validation and more reliable retrieval, reducing invalid-hostname issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->