### PR TITLE
update: pass commit_lock_file to `nix flake update`

### DIFF
--- a/src/darwin.rs
+++ b/src/darwin.rs
@@ -79,7 +79,11 @@ impl DarwinRebuildArgs {
     }
 
     if self.update_args.update_all || self.update_args.update_input.is_some() {
-      update(&self.common.installable, self.update_args.update_input)?;
+      update(
+        &self.common.installable,
+        self.update_args.update_input,
+        self.common.passthrough.commit_lock_file,
+      )?;
     }
 
     let hostname = get_hostname(self.hostname)?;

--- a/src/home.rs
+++ b/src/home.rs
@@ -62,7 +62,11 @@ impl HomeRebuildArgs {
     use HomeRebuildVariant::Build;
 
     if self.update_args.update_all || self.update_args.update_input.is_some() {
-      update(&self.common.installable, self.update_args.update_input)?;
+      update(
+        &self.common.installable,
+        self.update_args.update_input,
+        self.common.passthrough.commit_lock_file,
+      )?;
     }
 
     let (out_path, _tempdir_guard): (PathBuf, Option<tempfile::TempDir>) =

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -902,9 +902,6 @@ impl NixBuildPassthroughArgs {
       warn!("--no-registries is deprecated, use --no-use-registries instead");
       args.push("--no-use-registries".into());
     }
-    if self.commit_lock_file {
-      args.push("--commit-lock-file".into());
-    }
     if self.no_build_output {
       args.push("--no-build-output".into());
     }

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -441,6 +441,7 @@ impl OsRebuildArgs {
       update(
         &self.common.installable,
         self.update_args.update_input.clone(),
+        self.common.passthrough.commit_lock_file,
       )?;
     }
 

--- a/src/update.rs
+++ b/src/update.rs
@@ -6,6 +6,7 @@ use crate::{Result, commands::Command, installable::Installable};
 pub fn update(
   installable: &Installable,
   inputs: Option<Vec<String>>,
+  commit_lock_file: bool,
 ) -> Result<()> {
   let Installable::Flake { reference, .. } = installable else {
     warn!(
@@ -16,6 +17,10 @@ pub fn update(
   };
 
   let mut cmd = Command::new("nix").args(["flake", "update"]);
+
+  if commit_lock_file {
+    cmd = cmd.arg("--commit-lock-file");
+  }
 
   if let Some(inputs) = inputs {
     for input in &inputs {


### PR DESCRIPTION
It turns out most Nix commands take a `--commit-lock-file` flag, but only _some_ of them (I suppose the ones actually changing the `flake.lock`) actually run the commit. 

This stupid issue made me go read Nix source code, I hate everything now.

Pass the `commit_lock_file` from the passthrough
arguments to the update command and append
`--commit_lock_file` to the `nix flake update`
invocation, _hopefully_ fixing this for good.

Closes #512.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated update operation to handle lock file commit behavior through refactored internal APIs across multiple build contexts, consolidating how commit-related flags are processed during update workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->