### PR TITLE
{home, nixos}: prefer `--specialisation` command line flag over current specialisation

### DIFF
--- a/src/home.rs
+++ b/src/home.rs
@@ -184,7 +184,7 @@ impl HomeRebuildArgs {
     let target_specialisation = if self.no_specialisation {
       None
     } else {
-      current_specialisation.or(self.specialisation)
+      self.specialisation.or(current_specialisation)
     };
 
     debug!("target_specialisation: {target_specialisation:?}");

--- a/src/nixos.rs
+++ b/src/nixos.rs
@@ -571,35 +571,39 @@ impl OsRebuildArgs {
     let target_specialisation = if self.no_specialisation {
       None
     } else {
-      current_specialisation.or_else(|| self.specialisation.clone())
+      self.specialisation.clone().or(current_specialisation)
     };
 
     debug!("Target specialisation: {target_specialisation:?}");
 
-    let target_profile = target_specialisation.as_ref().map_or_else(
-      || out_path.to_path_buf(),
-      |spec| out_path.join("specialisation").join(spec),
-    );
+    // Determine target profile, falling back to base if specialisation doesn't
+    // exist
+    let target_profile = match &target_specialisation {
+      None => out_path.to_path_buf(),
+      Some(spec) => {
+        let spec_path = out_path.join("specialisation").join(spec);
+
+        // For local builds, check if specialisation exists and fall back if not
+        if out_path.exists() && !spec_path.exists() {
+          bail!(
+            "Specialisation '{}' does not exist in the built configuration",
+            spec
+          );
+        }
+
+        spec_path
+      },
+    };
 
     debug!("Output path: {out_path:?}");
     debug!("Target profile path: {}", target_profile.display());
 
-    // If out_path doesn't exist locally, assume it's remote and skip existence
-    // check
-    if out_path.exists() {
-      debug!("Target profile exists: {}", target_profile.exists());
-
-      if !target_profile
-        .try_exists()
-        .context("Failed to check if target profile exists")?
-      {
-        return Err(eyre!(
-          "Target profile path does not exist: {}",
-          target_profile.display()
-        ));
-      }
-    } else {
-      debug!("Output path is remote, skipping local existence check");
+    // Validate the final target profile exists if it's a local build
+    if out_path.exists() && !target_profile.exists() {
+      return Err(eyre!(
+        "Target profile path does not exist: {}",
+        target_profile.display()
+      ));
     }
 
     Ok(target_profile)


### PR DESCRIPTION
closes  #542 (hopefully) 
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prioritize explicit/specified specialisations over default/current ones when selecting profiles.
  * Stricter handling of missing local specialisations: non-existent paths now surface an error instead of silently falling back.
  * Simplified target-profile existence validation: local checks now return an explicit error if the chosen profile/output path is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->