### PR TITLE
clean: more reliably detect direnv gc roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@ functionality, under the "Removed" section.
     with a warning if NH can parse them.
 - Password caching now works across all remote operations.
 - Empty password validation prevents invalid credential caching.
+- Direnv caches in [alternative locations][direnv-alternative-caches] (e.g.,
+  `$XDG_CACHE_DIR/direnv/layouts`) will now be detected during `nh clean`.
+
+[direnv-alternative-caches]: https://github.com/direnv/direnv/wiki/Customizing-cache-location
 
 ### Removed
 

--- a/src/clean.rs
+++ b/src/clean.rs
@@ -28,7 +28,8 @@ use crate::{
 
 static DIRENV_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   #[allow(clippy::expect_used)]
-  Regex::new(r".*/.direnv/.*").expect("Failed to compile direnv regex")
+  Regex::new(r".*/(?:\.direnv|direnv/layouts)/.*")
+    .expect("Failed to compile direnv regex")
 });
 
 static RESULT_REGEX: LazyLock<Regex> = LazyLock::new(|| {


### PR DESCRIPTION
This will detect alternative direnv cache directories as described in https://github.com/direnv/direnv/wiki/Customizing-cache-location. There's no good way to exhaustively detect direnv caches, but this will catch the common cases.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

<!-- Message of single commit: -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved direnv cache detection during cleanup. The tool now identifies caches stored in alternative locations (such as XDG_CACHE_DIR/direnv/layouts) in addition to standard .direnv paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->