### PR TITLE
remote: use program name instead of full path

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -70,25 +70,17 @@ fn build_remote_command(
       .and_then(|name| name.to_str())
       .ok_or_else(|| eyre!("Failed to determine elevation program name"))?;
 
+    // Use just the program name on the remote host
+    // so that the remote system resolves it via its own PATH
     match (program_name, strategy) {
       // sudo passwordless: use --non-interactive to fail if password required
       ("sudo", ElevationStrategy::Passwordless) => {
-        Ok(format!(
-          "{} --non-interactive {}",
-          program.display(),
-          base_cmd
-        ))
+        Ok(format!("sudo --non-interactive {}", base_cmd))
       },
-      ("sudo", _) => {
-        Ok(format!(
-          "{} --prompt= --stdin {}",
-          program.display(),
-          base_cmd
-        ))
-      },
+      ("sudo", _) => Ok(format!("sudo --prompt= --stdin {}", base_cmd)),
       // doas passwordless: use -n flag (non-interactive)
       ("doas", ElevationStrategy::Passwordless) => {
-        Ok(format!("{} -n {}", program.display(), base_cmd))
+        Ok(format!("doas -n {}", base_cmd))
       },
       ("doas", _) => {
         bail!(
@@ -99,11 +91,7 @@ fn build_remote_command(
       },
       // run0 passwordless: use --no-ask-password flag
       ("run0", ElevationStrategy::Passwordless) => {
-        Ok(format!(
-          "{} --no-ask-password {}",
-          program.display(),
-          base_cmd
-        ))
+        Ok(format!("run0 --no-ask-password {}", base_cmd))
       },
       ("run0", _) => {
         bail!(


### PR DESCRIPTION
Use the program name instead of the full local path. Fixes issues where the path to an elevation program exists on the local machine, but *not* on the remote.

Closes #556.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for unsupported remote elevation combinations (e.g., certain non-interactive or stdin-based elevation paths), yielding clearer failures.

* **Refactor**
  * Simplified remote elevation command construction to rely on remote PATH resolution, producing leaner, program-name-based remote commands and more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->