### PR TITLE
search: add nixos-25.05 to DEPRECATED_VERSIONS

### DIFF
--- a/src/search.rs
+++ b/src/search.rs
@@ -19,7 +19,7 @@ use crate::{Result, interface};
 // List of deprecated NixOS versions
 // Add new versions as they become deprecated.
 const DEPRECATED_VERSIONS: &[&str] =
-  &["nixos-23.11", "nixos-24.05", "nixos-24.11"];
+  &["nixos-23.11", "nixos-24.05", "nixos-24.11", "nixos-25.05"];
 
 // Support for current version pattern
 static SUPPORTED_BRANCH_REGEX: OnceLock<Regex> = OnceLock::new();
@@ -335,10 +335,11 @@ fn supported_branch<S: AsRef<str>>(branch: S) -> bool {
 #[test]
 fn test_supported_branch() {
   assert!(supported_branch("nixos-unstable"));
-  assert!(supported_branch("nixos-25.05"));
+  assert!(supported_branch("nixos-25.11"));
   assert!(!supported_branch("nixos-unstable-small"));
   assert!(!supported_branch("nixos-24.05"));
   assert!(!supported_branch("nixos-24.11"));
+  assert!(!supported_branch("nixos-25.05"));
   assert!(!supported_branch("24.05"));
   assert!(!supported_branch("nixpkgs-darwin"));
   assert!(!supported_branch("nixpks-21.11-darwin"));


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version nixos-25.05 is now deprecated and no longer supported. Users should upgrade to a newer version.
  * Version nixos-25.11 is now officially supported.

* **Tests**
  * Updated test cases to reflect the latest version support matrix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->