### PR TITLE
docs: Move mention of formats for --keep-since to argument itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ functionality, under the "Removed" section.
   "unrecognised flag" errors.
 - nh now properly resolves installables, fixing issues when e.g. multiple
   `NH_{FLAKE,FILE,{OS,HOME_DARWIN}_FLAKE}` environment variables are set.
+- For the `--keep-since` flag, the explanation linking to the documentation of
+  the `humantime` crate is now shown.
 
 [direnv-alternative-caches]: https://github.com/direnv/direnv/wiki/Customizing-cache-location
 

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -449,10 +449,6 @@ pub enum CleanMode {
 }
 
 #[derive(Args, Clone, Debug)]
-#[clap(verbatim_doc_comment)]
-/// Enhanced nix cleanup
-///
-/// For --keep-since, see the documentation of humantime for possible formats: <https://docs.rs/humantime/latest/humantime/fn.parse_duration.html>
 pub struct CleanArgs {
   #[arg(long, short, default_value = "1")]
   /// At least keep this number of generations
@@ -460,6 +456,8 @@ pub struct CleanArgs {
 
   #[arg(long, short = 'K', default_value = "0h")]
   /// At least keep gcroots and generations in this time range since now.
+  ///
+  /// See the documentation of humantime for possible formats: <https://docs.rs/humantime/latest/humantime/fn.parse_duration.html>
   pub keep_since: humantime::Duration,
 
   /// Only print actions, without performing them


### PR DESCRIPTION
The old explanation linking to the humantime documentation was never shown, because the doc comment on `CleanMode` (the acual subcommand) was used.

This commit moves the link into the documentation for --keep-since itself. This is where I would have needed it when I tried out the tool for the first time today:

```
$ gh clean all --help
Clean all profiles

Usage: nh clean all [OPTIONS]

Options:
  -k, --keep <KEEP>
          At least keep this number of generations
          
          [default: 1]

  -v, --verbose...
          Increase logging verbosity

  -K, --keep-since <KEEP_SINCE>
          At least keep gcroots and generations in this time range since now.
          
          See the documentation of humantime for possible formats: <https://docs.rs/humantime/latest/humantime/fn.parse_duration.html>
          
          [default: 0h]
```

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->

## Sanity Checking

<!--
Please check all that apply. As before, this section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s)
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
