### PR TITLE
remote: show actual SSH command errors instead of misleading failure err

### DIFF
--- a/src/remote.rs
+++ b/src/remote.rs
@@ -855,7 +855,7 @@ pub fn validate_closure_remote(
     }
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    if !stderr.is_empty() {
+    if !stderr.trim().is_empty() {
       let host_context = context_info.map_or_else(
         || format!("on remote host '{host}'"),
         |ctx| format!("on remote host '{host}' ({ctx})"),
@@ -900,7 +900,7 @@ pub fn validate_closure_remote(
     }
   }
 
-  if !ssh_stderr.is_empty() {
+  if !ssh_stderr.trim().is_empty() {
     let host_context = context_info.map_or_else(
       || format!("on remote host '{host}'"),
       |ctx| format!("on remote host '{host}' ({ctx})"),


### PR DESCRIPTION
Ensure that when remote command execution fails, any error messages from `stderr` are captured and included in the error output, making debugging easier and error messages more informative. I think this is consistent with what the nixos-rebuild script does, essentially.

Change-Id: Icbb39f5f3df3c03562cfa6c40e50b4bb6a6a6964


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error reporting by capturing and surfacing remote command stderr. When remote checks fail (batch or per-file), errors now include host context and any captured remote output alongside existing missing-file diagnostics, making troubleshooting of remote executions clearer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->