### PR TITLE
nh-nixos: automatically print dix diff when current hostname matches target hostname

### DIFF
--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -89,7 +89,7 @@ impl args::OsArgs {
         }
         args.build_only(&Build, None, &elevation)
       },
-      OsSubcommand::BuildVm(args) => args.build_vm(elevation),
+      OsSubcommand::BuildVm(args) => args.build_vm(&elevation),
       OsSubcommand::Repl(args) => args.run(),
       OsSubcommand::Info(args) => args.info(),
       OsSubcommand::Rollback(args) => args.rollback(elevation),
@@ -109,7 +109,7 @@ enum OsRebuildVariant {
 }
 
 impl OsBuildVmArgs {
-  fn build_vm(self, elevation: ElevationStrategy) -> Result<()> {
+  fn build_vm(self, elevation: &ElevationStrategy) -> Result<()> {
     let attr = if self.with_bootloader {
       "vmWithBootLoader"
     } else {
@@ -126,7 +126,7 @@ impl OsBuildVmArgs {
 
     // Show warning if no hostname was explicitly provided for VM builds
     if self.common.hostname.is_none() {
-      let (_, target_hostname) = self.common.setup_build_context(&elevation)?;
+      let (_, target_hostname) = self.common.setup_build_context(elevation)?;
       tracing::warn!(
         "Guessing system is {target_hostname} for a VM image. If this isn't \
          intended, use --hostname to change."
@@ -136,7 +136,7 @@ impl OsBuildVmArgs {
     self.common.build_only(
       &OsRebuildVariant::BuildVm,
       Some(&[attr]),
-      &elevation,
+      elevation,
     )?;
 
     // If --run flag is set, execute the VM

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -626,31 +626,38 @@ impl OsRebuildArgs {
   }
 
   fn handle_dix_diff(&self, target_profile: &Path) {
+    let current_profile = PathBuf::from(CURRENT_PROFILE);
+
     match self.common.diff {
       DiffType::Always => {
-        let _ = print_dix_diff(&PathBuf::from(CURRENT_PROFILE), target_profile);
+        let _ = print_dix_diff(&current_profile, target_profile);
       },
       DiffType::Never => {
         debug!("Not running dix as the --diff flag is set to never.");
       },
       DiffType::Auto => {
-        // Only run dix if no explicit hostname was provided and no remote
-        // build/target host is specified, implying a local system build.
-        if self.hostname.is_none()
-          && self.target_host.is_none()
-          && self.build_host.is_none()
-        {
-          debug!(
-            "Comparing with target profile: {}",
+        // Since dix relies on both system's derivations existing on the local
+        // machine, we only generate the diff if no remote
+        // target host is specified, implying a local system build.
+        if self.target_host.is_some() {
+          debug!("Not running dix as a remote host is involved.");
+        } else if !current_profile.exists() {
+          warn!(
+            "current profile {} does not exist, skipping dix diffing",
+            current_profile.display()
+          );
+        } else if !target_profile.exists() {
+          warn!(
+            "target profile {} does not exist, skipping dix diffing",
             target_profile.display()
           );
-          let _ =
-            print_dix_diff(&PathBuf::from(CURRENT_PROFILE), target_profile);
         } else {
           debug!(
-            "Not running dix as a remote host is involved or an explicit \
-             hostname was provided."
+            "Comparing current profile {} with target profile: {}",
+            current_profile.display(),
+            target_profile.display()
           );
+          let _ = print_dix_diff(&current_profile, target_profile);
         }
       },
     }


### PR DESCRIPTION
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [ ] I have read and understood the [contribution guidelines]
- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Rebuild diff behavior refined: automatic diffs now skip for remote targets, run only when both current and target profiles exist, and emit warnings (instead of errors) when profiles are missing.

* **Refactor**
  * VM build activation flow streamlined to improve reliability and avoid elevation-related issues during VM builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->