### PR TITLE
workflows/tag: use personal access token when pushing tags

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -23,6 +23,7 @@ jobs:
         name: Checkout
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT }}
 
       - name: Read version
         run: |
@@ -36,8 +37,6 @@ jobs:
           echo "Read version: $VERSION"
 
       - name: Tag
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
         run: |
           set -e
           if git rev-parse "$nh_version" >/dev/null 2>&1; then


### PR DESCRIPTION
Setting GH_TOKEN in the `tag.Tag` step has no effect, as the step does not use `gh` at all.

Setting the token in the checkout action sets up the git repository to use the token for subsequent git operations (like push).

This matters because the `build` job (and therefore the `release`) job need to run on the event created when the tag is pushed.

The default credentials that were used, however, do not trigger CI, so the needed event is never created.

P.S. It looks like you forgot to update the CHANGELOG for the release. Not sure how you'd like to handle that.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [ ] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [ ] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration for improved token management in the tagging process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->