### PR TITLE
Added note about gcroots cleanup in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -249,6 +249,12 @@ the cleanup process to let you know what is to be cleaned.
     >
   </p>
 
+> [!NOTE]
+> By default `nh clean` will automatically clean up your
+> [gcroots](https://nixos.org/guides/nix-pills/11-garbage-collector.html#indirect-roots)
+> directory, which will remove all your built result and direnv directories. If
+> you do not want to have this behaviour you can use the flag `--no-gcroots`.
+
 ### Platform Specific Subcommands
 
 Platform specific subcommands are those that implement CLI utilities for


### PR DESCRIPTION
For half a year I was always wondering why nixos is always removing all my devshells for my projects. I recently figured out that this behaviour comes from the cleanup process of gcroots of nh clean. The only note about this from what I have seen is in the help about the `--no-gcroots` flag. I think this default behaviour should be documented a bit better. What do you think about it?
<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [x] `aarch64-linux`
  - [x] `x86_64-darwin`
  - [x] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `nh clean` command's new automatic cleanup behavior.
  * Documented the `--no-gcroots` flag to disable automatic cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->