### PR TITLE
Fix remaining check failures and improve CI to prevent regressions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,10 +1,11 @@
-name: "Check formating & lints"
+name: "Check formatting & lints"
 
 on:
   workflow_dispatch:
   pull_request:
     branches: ["master"]
     paths:
+      - "Justfile"
       - "Cargo.toml"
       - "Cargo.lock"
       - "xtask/Cargo.toml"
@@ -16,6 +17,7 @@ on:
     branches-ignore:
       - "update-*"
     paths:
+      - "Justfile"
       - "Cargo.toml"
       - "Cargo.lock"
       - "xtask/Cargo.toml"
@@ -36,30 +38,7 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Check if the source code is formatted as per the tooling configurations
-      # in the repository root. Unlike the Clippy lints below, formatting lints
-      # **must** pass.
-      - name: Prepare Dev Environment
+      - name: Checking Code (format, lints, etc.)
         run: |
           eval "$(nix print-dev-env)"
-          set -x
-
-          # Verify that Rust source code is formatted
-          cargo fmt --check || exit 1
-
-          # Verify that TOML files are formatted
-          taplo fmt --check || exit 1
-
-      # We run clippy with lints that help avoid overall low-quality code or what is called "code smell."
-      # Stylistic lints (e.g., clippy::style and clippy::complexity) are avoided but it is a good idea to
-      # follow those while working on the codebase.
-      - name: Clippy Lints
-        run: |
-          eval "$(nix print-dev-env)"
-          set -x
-
-          # Lint Changes
-          cargo clippy -- \
-            -W clippy::pedantic \
-            -W clippy::correctness \
-            -W clippy::suspicious
+          just check || exit 1

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -22,7 +22,7 @@ jobs:
         nix flake update
         eval "$(nix print-dev-env)"
         cargo update
-        ./fix.sh
+        just fix
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v8

--- a/crates/nh-core/src/command.rs
+++ b/crates/nh-core/src/command.rs
@@ -84,8 +84,8 @@ pub fn exec_with_streaming(
     }
   });
 
-  let stderr_thread = if let Some(stderr_pipe) = job.stderr.take() {
-    Some(std::thread::spawn(move || {
+  let stderr_thread = job.stderr.take().map(|stderr_pipe| {
+    std::thread::spawn(move || {
       let mut stderr_reader = std::io::BufReader::new(stderr_pipe);
       let mut stderr_bytes = Vec::new();
       let mut stderr_buf = [0u8; 4096];
@@ -112,10 +112,8 @@ pub fn exec_with_streaming(
       } else {
         String::new()
       }
-    }))
-  } else {
-    None
-  };
+    })
+  });
 
   let exit_status = job
     .wait()

--- a/docs/README.md
+++ b/docs/README.md
@@ -426,10 +426,8 @@ generate manpages and possibly more in the future.
 
 ### Submitting Changes
 
-Once your changes are complete, please remember to run the fixup script in
-[fix.sh](./fix.sh) to apply general formatter and linter rules that will be
-expected by the CI. This is optional, but some CI steps (such as formatting) is
-required for a merge.
+Once your changes are complete, please remember to run `just fix` to apply
+general formatter and linter rules that will be expected by the CI.
 
 You will also want to update the [changelog](/CHANGELOG.md) with sufficient
 amount of information to detail the new behaviour before you create your


### PR DESCRIPTION
This is a more wholistic fix to #596:

1. First, get everything in a working order by running `just fix`.
2. Update the `update.yml` workflow to use `just fix` instead of the now-deleted `./fix.sh`.
3. Update the REAMDE to reference `just fix` instead of `./fix.sh`.
4. Update CI to run `just fix` instead of replicating it ad-hoc.

Motivation: I'd like to contribute more to this project but it's difficult to do that when the built-in fix/lint tools make changes and call out errors unrelated to my contributions.

I understand that this PR is very much "getting up in the maintainer's business" and won't take any offense if you want to close this and do it your own way, or cherry-pick what you want and leave the rest. But I figured an external contributor's perspective might be helpful here.

<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [ ] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [ ] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflows renamed and updated to run unified check/fix commands and to also trigger on task file changes
  * Dependency update flow now uses the unified fix command after updates
* **Documentation**
  * Contributor guide updated to reference the current fix/check commands
* **Refactor**
  * Internal command execution streamlined for cleaner error-output handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->