### PR TITLE
nh-remote: fix indicatif spinner for closure copying

### DIFF
--- a/crates/nh-remote/src/remote.rs
+++ b/crates/nh-remote/src/remote.rs
@@ -806,40 +806,6 @@ fn run_remote_command(
   }
 }
 
-/// Copy a Nix closure to a remote host.
-fn copy_closure_to(
-  host: &RemoteHost,
-  path: &str,
-  use_substitutes: bool,
-) -> Result<()> {
-  info!("Copying closure to build host '{}'", host);
-
-  let mut cmd = Exec::cmd("nix-copy-closure")
-    .arg("--to")
-    .arg(host.ssh_host());
-
-  if use_substitutes {
-    cmd = cmd.arg("--use-substitutes");
-  }
-
-  cmd = cmd.arg(path).env("NIX_SSHOPTS", get_nix_sshopts_env());
-
-  debug!(?cmd, "nix-copy-closure --to");
-
-  let (exit_status, _stdout, _stderr) = exec_with_streaming(cmd, false)
-    .wrap_err("Failed to copy closure to remote host")?;
-
-  if !exit_status.success() {
-    bail!(
-      "nix-copy-closure --to '{}' failed (exit status: {:?})",
-      host,
-      exit_status
-    );
-  }
-
-  Ok(())
-}
-
 /// Validates that essential files exist in a closure on a remote host.
 ///
 /// Performs batched SSH checks using connection multiplexing. This is useful
@@ -1558,7 +1524,7 @@ pub fn build_remote(
   let drv_path = eval_drv_path(installable)?;
 
   // Step 2: Copy derivation to build host
-  copy_closure_to(build_host, &drv_path, use_substitutes)?;
+  copy_to_remote(build_host, &drv_path, use_substitutes)?;
 
   // Step 3: Build on remote
   info!("Building on remote host '{}'", build_host);

--- a/crates/nh-remote/src/remote.rs
+++ b/crates/nh-remote/src/remote.rs
@@ -1382,7 +1382,7 @@ const NIXOS_SYSTEM_PROFILE: &str = "/nix/var/nix/profiles/system";
 
 /// Evaluate a flake installable to get its derivation path.
 /// Matches nixos-rebuild-ng: `nix eval --raw <flake>.drvPath`
-fn eval_drv_path(installable: &Installable) -> Result<String> {
+fn eval_drv_path(installable: &Installable) -> Result<PathBuf> {
   // Build the installable with .drvPath appended
   let drv_installable = match installable {
     Installable::Flake {
@@ -1448,12 +1448,15 @@ fn eval_drv_path(installable: &Installable) -> Result<String> {
     );
   }
 
-  let drv_path = capture.stdout_str().trim().to_string();
-  if drv_path.is_empty() {
-    bail!("nix eval returned empty derivation path");
+  let drv_path = PathBuf::from(capture.stdout_str().trim().to_string());
+  if !drv_path.is_file() {
+    bail!(
+      "nix eval returned invalid derivation path: {}",
+      drv_path.display()
+    );
   }
 
-  debug!("Derivation path: {}", drv_path);
+  debug!("Derivation path: {}", drv_path.display());
   Ok(drv_path)
 }
 
@@ -1617,11 +1620,11 @@ pub fn build_remote(
 /// Returns the output path.
 fn build_on_remote(
   host: &RemoteHost,
-  drv_path: &str,
+  drv_path: &Path,
   config: &RemoteBuildConfig,
 ) -> Result<String> {
   // Build command: nix build <drv>^* --print-out-paths [extra_args...]
-  let drv_with_outputs = format!("{drv_path}^*");
+  let drv_with_outputs = format!("{}^*", drv_path.display());
 
   if config.use_nom {
     // Check that nom is available before attempting to use it


### PR DESCRIPTION


<!--
^ Please include a clear and concise description of the aim of your Pull Request above this line ^

For plugin dependency/module additions, please make sure to link the source link
of the added plugin or dependency in this section. If your pull request aims to
fix an open issue or bug, please also link the relevant issue below this
line. You may attach an issue to your pull request with `Fixes #<issue number>`
above this comment, and it will be closed when your pull request is merged.
-->
<!--markdownlint-disable MD041-->

## Sanity Checking

<!--
Please check all that apply. This section is not a hard requirement
but checklists with more checked items are likely to be merged faster. You may
save some time in maintainer reviews by performing self-reviews here before
submitting your pull request.

If your pull request includes any change or unexpected behaviour not covered below,
please do make sure to include it above in your description.
-->

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [ ] I have updated the [changelog] as per my changes
- [ ] I have tested, and self-reviewed my code
- Style and consistency
  - [ ] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [ ] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [ ] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [ ] My code includes comments in particularly complex areas to explain the
        logic
  - [ ] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [ ] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced remote build flow with improved path validation and error handling to increase robustness in internal build operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->