### PR TITLE
nh-nixos: probe remote uid before electing to elevate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ functionality, under the "Removed" section.
 
 ### Fixed
 
+- `nh os switch --target-host root@host` no longer wraps the activation in
+  `sudo --prompt= --stdin` when the SSH user is already uid 0. The elevation
+  decision now probes `id -u` over the established ControlMaster instead of
+  reading the local process uid, matching `nixos-rebuild` behaviour and
+  unblocking sudo shims that don't accept stdin passwords (e.g.
+  `run0-sudo-shim`).
 - The regression introduced by the `Subprocess` crate upgrade causing various
   event outputs to be printed incorrectly should now be resolved.
 - `nh os info` now batches `nix path-info` calls into a single invocation

--- a/crates/nh-nixos/src/nixos.rs
+++ b/crates/nh-nixos/src/nixos.rs
@@ -158,7 +158,7 @@ impl OsRebuildActivateArgs {
   ) -> Result<()> {
     use OsRebuildVariant::{Build, BuildVm};
 
-    let (elevate, target_hostname) =
+    let (local_elevate, target_hostname) =
       self.rebuild.setup_build_context(&elevation)?;
 
     let (out_path, _tempdir_guard) =
@@ -207,6 +207,13 @@ impl OsRebuildActivateArgs {
       Some(guard)
     } else {
       None
+    };
+
+    // Now that the ControlMaster is up, probe the remote uid for elevation.
+    let elevate = if self.rebuild.target_host.is_some() {
+      self.rebuild.determine_remote_elevation(&elevation)?
+    } else {
+      local_elevate
     };
 
     let actual_store_path =
@@ -450,7 +457,9 @@ impl OsRebuildArgs {
   ///
   /// This includes:
   /// - Ensuring SSH key login if a remote build/target host is involved.
-  /// - Checking and determining elevation status.
+  /// - Determining elevation status for local activation; the remote case is
+  ///   handled by [`Self::determine_remote_elevation`] after the SSH
+  ///   `ControlMaster` is up.
   /// - Performing updates to Nix inputs if specified.
   /// - Resolving the target hostname for the build.
   ///
@@ -458,7 +467,10 @@ impl OsRebuildArgs {
   ///
   /// `Result` containing a tuple:
   ///
-  /// - `bool`: `true` if elevation is required, `false` otherwise.
+  /// - `bool`: `true` if local elevation is required. When `target_host` is set
+  ///   this value is meaningless (returned as `false`), and the real answer is
+  ///   produced by [`Self::determine_remote_elevation`] once the SSH
+  ///   `ControlMaster` is up.
   /// - `String`: The resolved target hostname.
   fn setup_build_context(
     &self,
@@ -469,7 +481,12 @@ impl OsRebuildArgs {
       ensure_ssh_key_login()?;
     }
 
-    let elevate = has_elevation_status(self.bypass_root_check, elevation)?;
+    // We still call this for the local-root guard it performs, even though
+    // remote-target flows take their elevate answer from
+    // `determine_remote_elevation` later.
+    let local_elevate =
+      has_elevation_status(self.bypass_root_check, elevation)?;
+    let elevate = self.target_host.is_none() && local_elevate;
 
     let target_hostname = get_hostname(
       self
@@ -479,6 +496,30 @@ impl OsRebuildArgs {
         .map(ToOwned::to_owned),
     )?;
     Ok((elevate, target_hostname))
+  }
+
+  /// Probe the remote uid to decide whether activation needs elevation.
+  ///
+  /// This must be called after [`nh_remote::open_ssh_control_master`]
+  /// so the probe reuses the established connection.
+  ///
+  /// # Returns
+  ///
+  /// `false` when `target_host` is unset (caller should use
+  /// [`Self::setup_build_context`] or [`has_elevation_status`] for the
+  /// local case) or when the elevation strategy is [`None`].
+  fn determine_remote_elevation(
+    &self,
+    elevation: &ElevationStrategy,
+  ) -> Result<bool> {
+    let Some(target_host) = &self.target_host else {
+      return Ok(false);
+    };
+    if matches!(elevation, ElevationStrategy::None) {
+      return Ok(false);
+    }
+    let uid = nh_remote::probe_remote_uid(target_host)?;
+    Ok(uid != 0)
   }
 
   fn determine_output_path(

--- a/crates/nh-remote/src/remote.rs
+++ b/crates/nh-remote/src/remote.rs
@@ -297,6 +297,46 @@ pub fn open_ssh_control_master(host: &RemoteHost) -> Result<()> {
   Ok(())
 }
 
+/// Probe the effective uid on the remote host after SSH login.
+///
+/// This runs `id -u` over the already-opened `ControlMaster` connection and
+/// returns the parsed value. Callers use this to decide whether elevation is
+/// needed without trusting the username convention.
+///
+/// This must be called after [`open_ssh_control_master`] so the multiplexed
+/// connection is already up.
+///
+/// # Errors
+///
+/// Returns an error if the SSH connection fails, `id -u` exits non-zero, or
+/// its stdout cannot be parsed as a `u32`.
+pub fn probe_remote_uid(host: &RemoteHost) -> Result<u32> {
+  let ssh_opts = get_ssh_opts();
+  let mut cmd = Exec::cmd("ssh");
+  for opt in &ssh_opts {
+    cmd = cmd.arg(opt);
+  }
+  cmd = cmd.arg("-T").arg(host.ssh_host()).arg("id -u");
+
+  let capture = cmd
+    .capture()
+    .wrap_err_with(|| format!("Failed to probe remote uid on '{host}'"))?;
+
+  if !capture.exit_status.success() {
+    bail!(
+      "Remote uid probe on '{}' failed:\n{}",
+      host,
+      capture.stderr_str().trim()
+    );
+  }
+
+  capture
+    .stdout_str()
+    .trim()
+    .parse::<u32>()
+    .wrap_err_with(|| format!("Unexpected `id -u` output from '{host}'"))
+}
+
 /// Cache for the SSH control socket directory.
 static SSH_CONTROL_DIR: OnceLock<PathBuf> = OnceLock::new();
 


### PR DESCRIPTION
`has_elevation_status` checks the local uid, but that's the wrong machine when activation runs on a remote host. As a result `--target-host root@server` ended up wrapping the activation in `sudo --prompt= --stdin`, which breaks against run0-style sudo shims that don't accept stdin passwords. This commit probes `id -u` over the existing ControlMaster instead, and treats uid 0 as no-elevation.

## Sanity Checking

[contribution guidelines]: https://github.com/nix-community/nh/blob/master/CONTRIBUTING.md
[changelog]: https://github.com/nix-community/nh/tree/master/CHANGELOG.md

- [x] I have read and understood the [contribution guidelines]
- [x] I have updated the [changelog] as per my changes
- [x] I have tested, and self-reviewed my code
- Style and consistency
  - [x] I ran **`nix fmt`** to format my Nix code
  - [x] I ran **`cargo fmt`** to format my Rust code
  - [x] I have added appropriate documentation to new code
  - [x] My changes are consistent with the rest of the codebase
- Correctness
  - [x] I ran **`cargo clippy`** and fixed any new linter warnings.
- If new changes are particularly complex:
  - [x] My code includes comments in particularly complex areas to explain the
        logic
  - [x] I have documented the motive for those changes in the PR body or commit
        description.
- Tested on platform(s):
  - [x] `x86_64-linux`
  - [x] `aarch64-linux`
  - [ ] `x86_64-darwin`
  - [ ] `aarch64-darwin`

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/nix-community/nh/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Remote build elevation detection now probes the actual remote user's UID over the established SSH connection, avoiding unnecessary sudo wrapping when the remote account is already root and handling cases where sudo shims don't accept stdin passwords.
* **Changed**
  * `nh search` backend updated to a newer Elasticsearch version for improved search behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nix-community/nh/pull/646)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->